### PR TITLE
Models string representation for Python 3

### DIFF
--- a/django_walletpass/apps.py
+++ b/django_walletpass/apps.py
@@ -3,6 +3,7 @@ from django.apps import AppConfig
 
 class DjangoWalletpassConfig(AppConfig):
     name = 'django_walletpass'
+    verbose_name = 'Django walletpass'
 
     def ready(self):
         from django_walletpass import signals as _signals  # pylint: disable=import-outside-toplevel

--- a/django_walletpass/models.py
+++ b/django_walletpass/models.py
@@ -285,6 +285,9 @@ class Pass(models.Model):
     def __unicode__(self):
         return self.serial_number
 
+    def __str__(self):
+        return self.serial_number
+
     class Meta:
         verbose_name_plural = "passes"
         unique_together = (
@@ -308,6 +311,9 @@ class Registration(models.Model):
     def __unicode__(self):
         return self.device_library_identifier
 
+    def __str__(self):
+        return self.device_library_identifier
+
 
 class Log(models.Model):
     """
@@ -316,4 +322,7 @@ class Log(models.Model):
     message = models.TextField()
 
     def __unicode__(self):
+        return self.message
+
+    def __str__(self):
         return self.message


### PR DESCRIPTION
Starting from Python 3, the __str__ method was introduced as a replacement for __unicode__. 