### PR TITLE
Fix issues with LogViewSet JSON data handling and timestamp parsing

### DIFF
--- a/django_walletpass/classviews.py
+++ b/django_walletpass/classviews.py
@@ -138,8 +138,7 @@ class LogViewSet(viewsets.ViewSet):
     permission_classes = (AllowAny, )
 
     def create(self, request):
-        json_body = json.loads(request.body)
-        for message in json_body['logs']:
+        for message in request.data.get('logs', []):
             log = Log(message=message)
             Log.parse_log(log, message)
         return Response({}, status=status.HTTP_200_OK)

--- a/django_walletpass/models.py
+++ b/django_walletpass/models.py
@@ -382,7 +382,7 @@ class Log(models.Model):
         elif 'warning' in status:
             status = 'warning'
 
-        log.created_at = datetime.datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S %z")
+        log.created_at = datetime.datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S %p %z")
         log.status = status
         log.task_type = task_type
         log.device_id = device_id

--- a/django_walletpass/tests/main.py
+++ b/django_walletpass/tests/main.py
@@ -1,14 +1,19 @@
+import datetime
+import json
 from unittest import mock
 
 from dateutil.parser import parse
 from django.contrib import admin
 from django.test import TestCase
+from django.urls import reverse
 from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase, APIRequestFactory
 
 from django_walletpass import crypto
 from django_walletpass.admin import PassAdmin
-from django_walletpass.classviews import FORMAT
-from django_walletpass.models import Pass, PassBuilder, Registration
+from django_walletpass.classviews import FORMAT, LogViewSet
+from django_walletpass.models import Pass, PassBuilder, Registration, Log
 from django_walletpass.settings import dwpconfig as WALLETPASS_CONF
 
 
@@ -116,3 +121,30 @@ class ModelTestCase(TestCase):
             send_notification_mock.assert_called_with(mock.ANY)
             request = send_notification_mock.call_args_list[0][0][0]
             self.assertEqual(request.message, {"aps": {}})
+
+
+class LogViewSetTestCase(APITestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def test_create_log(self):
+        url = reverse('walletpass_log', urlconf='django_walletpass.urls')
+        expected_timestamp_str = "2024-07-08 10:22:35 AM +0200"
+        data = {
+            'logs': [f"[{expected_timestamp_str}] Web service error for pass.com.develatio.devpubs.example ("
+                     "https://example.com/passes/): Response to 'What changed?' "
+                     "request included 1 serial numbers but the lastUpdated tag (2024-07-08T08:03:13.588412+00:00) "
+                     "remained the same."]
+        }
+        request = self.factory.post(url, data=json.dumps(data), content_type='application/json')
+        view = LogViewSet.as_view({'post': 'create'})
+        response = view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        created_log = Log.objects.first()
+        self.assertIsNotNone(created_log)
+        expected_timestamp = datetime.datetime.strptime(expected_timestamp_str, "%Y-%m-%d %I:%M:%S %p %z")
+        expected_utc_timestamp = expected_timestamp.astimezone(timezone.utc)
+
+        self.assertEqual(created_log.created_at, expected_utc_timestamp)


### PR DESCRIPTION
Fix issues with LogViewSet JSON data handling and timestamp parsing

Addressed problems encountered in LogViewSet related to JSON data handling and timestamp parsing with AM/PM format. This commit resolves the following issues:

- Improved handling of request.body in LogViewSet's create method to prevent RawPostDataException by utilizing DRF's request (`request.data`) instead of direct access to `request.body`.
- Enhanced timestamp parsing in Log.parse_log to correctly interpret timestamps containing AM/PM indicators (`%p`) using `datetime.datetime.strptime`.

Testing Scenario:
- Tested LogViewSet endpoint functionality to ensure proper handling of incoming JSON data and accurate timestamp parsing.

Details:
- Adjusted LogViewSet.create to align with Django and DRF conventions for handling request data.
- Updated Log.parse_log to include `%p` in the format string for parsing timestamps accurately.

This commit addresses issue #34 

