### PR TITLE
Fix RegisterPassViewSet.destroy logic and add unit tests

### DIFF
--- a/django_walletpass/classviews.py
+++ b/django_walletpass/classviews.py
@@ -97,7 +97,7 @@ class RegisterPassViewSet(viewsets.ViewSet):
             device_library_identifier=device_library_id,
             pazz=pass_,
         )
-        if registration:
+        if not registration:
             return Response({}, status=status.HTTP_200_OK)
         registration.delete()
         PASS_UNREGISTERED.send(sender=pass_)

--- a/django_walletpass/tests/main.py
+++ b/django_walletpass/tests/main.py
@@ -3,13 +3,17 @@ from unittest import mock
 from dateutil.parser import parse
 from django.contrib import admin
 from django.test import TestCase
+from django.urls import reverse
 from django.utils import timezone
+from rest_framework import status
 
 from django_walletpass import crypto
 from django_walletpass.admin import PassAdmin
-from django_walletpass.classviews import FORMAT
+from django_walletpass.classviews import FORMAT, RegisterPassViewSet
 from django_walletpass.models import Pass, PassBuilder, Registration
 from django_walletpass.settings import dwpconfig as WALLETPASS_CONF
+
+from rest_framework.test import APITestCase, APIRequestFactory
 
 
 class AdminTestCase(TestCase):
@@ -116,3 +120,83 @@ class ModelTestCase(TestCase):
             send_notification_mock.assert_called_with(mock.ANY)
             request = send_notification_mock.call_args_list[0][0][0]
             self.assertEqual(request.message, {"aps": {}})
+
+
+class RegisterPassViewSetTestCase(APITestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        builder = PassBuilder()
+        builder.pass_data = {
+            "formatVersion": 1,
+            "barcode": {
+                "message": "123456789",
+                "format": "PKBarcodeFormatPDF417",
+                "messageEncoding": "iso-8859-1",
+            },
+            "organizationName": "Organic Produce",
+            "description": "Organic Produce Loyalty Card",
+            "logoText": "Organic Produce",
+            "foregroundColor": "rgb(255, 255, 255)",
+            "backgroundColor": "rgb(55, 117, 50)",
+        }
+
+        builder.build()
+        instance = builder.write_to_model()
+        instance.save()
+        self.pass_instance = instance
+        self.pass_type_id = instance.pass_type_identifier
+        self.device_library_id = 'ebc6fdbd52ffd906fc294aba259f239c'
+        self.registration = Registration.objects.create(
+            device_library_identifier=self.device_library_id,
+            pazz=self.pass_instance
+        )
+        self.view = RegisterPassViewSet.as_view({'delete': 'destroy'})
+
+    def test_destroy_registration_exists(self):
+        existing_url = reverse(
+            'walletpass_register_pass',
+            args=[
+                self.device_library_id,
+                self.pass_type_id,
+                self.pass_instance.serial_number
+            ],
+            urlconf='django_walletpass.urls')
+
+        self.assertEqual(Registration.objects.count(), 1)
+        request = self.factory.delete(existing_url,
+                                      HTTP_AUTHORIZATION=f'ApplePass {self.pass_instance.authentication_token}')
+        response = self.view(request,
+                             device_library_id=self.device_library_id,
+                             pass_type_id=self.pass_instance.pass_type_identifier,
+                             serial_number=self.pass_instance.serial_number)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(Registration.objects.filter(device_library_identifier=self.device_library_id,
+                                                     pazz=self.pass_instance).exists())
+        self.assertEqual(Registration.objects.count(), 0)
+
+    def test_destroy_registration_not_exists(self):
+        non_existing_device_library_id = 'd4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9'
+        non_existing_url = reverse(
+            'walletpass_register_pass',
+            args=[
+                non_existing_device_library_id,
+                self.pass_type_id,
+                self.pass_instance.serial_number
+            ],
+            urlconf='django_walletpass.urls'
+        )
+        self.assertEqual(Registration.objects.count(), 1)
+
+        request = self.factory.delete(non_existing_url,
+                                      HTTP_AUTHORIZATION=f'ApplePass {self.pass_instance.authentication_token}')
+        response = self.view(request,
+                             device_library_id=non_existing_device_library_id,
+                             pass_type_id=self.pass_type_id,
+                             serial_number=self.pass_instance.serial_number)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Registration.objects.count(), 1)
+        self.assertTrue(Registration.objects.filter(device_library_identifier=self.device_library_id,
+                                                    pazz=self.pass_instance).exists())
+


### PR DESCRIPTION
### **Fix Logical Error in `RegisterPassViewSet.destroy` Method and Add Corresponding Unit Tests**

#### **Description**
This pull request addresses an issue in the `RegisterPassViewSet` class where the `destroy` method does not delete a registration when one exists. The current logic incorrectly returns a `200 OK` response without performing the deletion. The changes made include:

- Correcting the logic in the `destroy` method to ensure that the registration is deleted when found.
- Adding unit tests to verify the correct behavior of the `destroy` method.

#### **Changes Made**

**Corrected Logic in `destroy` Method:**

- Changed the condition from `if registration:` to `if not registration:` to properly delete the registration if it exists.
- Ensured that a `200 OK` response is returned when no registration exists, as expected.

**Added Unit Tests:**

1. **Test for Existing Registration**: Verifies that the registration is deleted successfully if exists.
2. **Test for Non-Existing Registration**: Verifies that a `200 OK` response is returned when the registration does not exist, and ensures that no registrations are deleted accidentally.


This commit addresses issue [#33](https://github.com/Develatio/django-walletpass/issues/33).
