### PR TITLE
uninstalled pass gets locally deleted

### DIFF
--- a/django_walletpass/classviews.py
+++ b/django_walletpass/classviews.py
@@ -1,26 +1,24 @@
 import json
 from calendar import timegm
 
-from pytz.exceptions import NonExistentTimeError
-
-import django.dispatch
 from dateutil.parser import parse
 from django.db.models import Max
 from django.http import HttpResponse
 from django.middleware.http import ConditionalGetMiddleware
 from django.shortcuts import get_object_or_404
 from django.utils.http import http_date
+from pytz.exceptions import NonExistentTimeError
 from rest_framework import status, viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
+
 from django_walletpass.models import Log, Pass, Registration
 from django_walletpass.settings import dwpconfig as WALLETPASS_CONF
+from django_walletpass.signals import PASS_REGISTERED, PASS_UNREGISTERED
 
 # legacy constant, remove when it can be assumed no timestamps of this format are out
 # there anymore
-FORMAT = '%Y-%m-%d %H:%M:%S'
-PASS_REGISTERED = django.dispatch.Signal()
-PASS_UNREGISTERED = django.dispatch.Signal()
+FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
 def get_pass(pass_type_id, serial_number):

--- a/django_walletpass/signals.py
+++ b/django_walletpass/signals.py
@@ -1,8 +1,25 @@
+from aioapns.common import APNS_RESPONSE_CODE
 from django.db.models.signals import post_save
-from django.dispatch import receiver
-from django_walletpass.models import Pass
+from django.dispatch import Signal, receiver
+
+from django_walletpass.models import Pass, Registration
+
+TOKEN_UNREGISTERED = Signal()
+PASS_REGISTERED = Signal()
+PASS_UNREGISTERED = Signal()
 
 
 @receiver(post_save, sender=Pass)
 def send_push_notification(instance=None, **_kwargs):
     instance.push_notification()
+
+
+@receiver(TOKEN_UNREGISTERED)
+def delete_registration(notification_request, notification_result, **kwargs):
+    if notification_result.status == APNS_RESPONSE_CODE.GONE:
+        registration = Registration.objects.get(
+            push_token=notification_request.device_token
+        )
+        pass_ = registration.pazz
+        registration.delete()
+        PASS_UNREGISTERED.send(sender=pass_)


### PR DESCRIPTION
when Apple APNS service returns 410 while trying to send a push notification, our local db might be outdated. hence we must delete the local registration.

- added code
- added tests
- updated changeme/release notes/readme